### PR TITLE
Add Drive watcher for live KPI updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A modern, robust KPI dashboard for tyre production analytics. All data is loaded
 - Advanced analytics and anomaly detection
 - Minimal, modern UI (only key KPIs and trends)
 - Modular codebase: data loading, KPI engine, quality checker, and Drive sync are separated for maintainability
+- Background watcher keeps local data synced with Drive (Excel & PNG files)
+- Handles multiple data granularities; raw spreadsheets and image assets are stored for downstream analysis
 
 ## Folder Structure
 - `app.py` — Main entry point
@@ -19,8 +21,9 @@ A modern, robust KPI dashboard for tyre production analytics. All data is loaded
 
 ## Usage
 1. Place your Google Drive credentials in `credentials.json`.
-2. Run the app: `streamlit run app.py`
-3. All analytics are auto-updated from your Drive folder.
+2. Start the Drive watcher: `python helpers/drive_watcher.py` (runs continuously)
+3. Run the app: `streamlit run app.py`
+4. All analytics are auto-updated from your Drive folder.
 
 ## Maintenance
 - Only keep files and modules listed above. Remove legacy/unused files for clarity.

--- a/helpers/drive_browser.py
+++ b/helpers/drive_browser.py
@@ -5,6 +5,8 @@ from googleapiclient.errors import HttpError
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 from typing import List, Dict
+import io
+from googleapiclient.http import MediaIoBaseDownload
 
 SCOPES = ['https://www.googleapis.com/auth/drive.metadata.readonly',
           'https://www.googleapis.com/auth/drive.readonly']
@@ -26,14 +28,17 @@ def get_drive_service():
             pickle.dump(creds, token)
     return build('drive', 'v3', credentials=creds)
 
-def list_excel_files_in_folder(folder_id: str) -> List[Dict]:
-    """List Excel files in a Google Drive folder, sorted by last modified."""
+def list_files_in_folder(folder_id: str, mime_types: List[str]) -> List[Dict]:
+    """List files in a Google Drive folder matching given MIME types."""
     service = get_drive_service()
-    query = f"'{folder_id}' in parents and (mimeType='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' or mimeType='application/vnd.ms-excel') and trashed=false"
-    results = service.files().list(q=query,
-                                   spaces='drive',
-                                   fields="files(id, name, modifiedTime, owners, lastModifyingUser)",
-                                   orderBy="modifiedTime desc").execute()
+    mime_query = " or ".join([f"mimeType='{m}'" for m in mime_types])
+    query = f"'{folder_id}' in parents and ({mime_query}) and trashed=false"
+    results = service.files().list(
+        q=query,
+        spaces='drive',
+        fields="files(id, name, mimeType, modifiedTime, owners, lastModifyingUser)",
+        orderBy="modifiedTime desc",
+    ).execute()
     return results.get('files', [])
 
 def get_file_activity(file_id: str) -> Dict:
@@ -47,11 +52,10 @@ def download_file(file_id: str, dest_path: str):
     """Download a file from Google Drive to dest_path."""
     service = get_drive_service()
     request = service.files().get_media(fileId=file_id)
-    with open(dest_path, 'wb') as f:
-        downloader = build('drive', 'v3', credentials=service._http.credentials).files().get_media(fileId=file_id)
-        done = False
-        while not done:
-            status, done = downloader.next_chunk()
-            if status:
-                print(f"Download {int(status.progress() * 100)}%.")
-        f.write(request.execute())
+    fh = io.FileIO(dest_path, 'wb')
+    downloader = MediaIoBaseDownload(fh, request)
+    done = False
+    while not done:
+        status, done = downloader.next_chunk()
+        if status:
+            print(f"Download {int(status.progress() * 100)}%")

--- a/helpers/drive_sync.py
+++ b/helpers/drive_sync.py
@@ -1,12 +1,30 @@
-from helpers.drive_browser import list_excel_files_in_folder, download_file
+import os
+from helpers.drive_browser import list_files_in_folder, download_file
 
 FOLDER_ID = "1-1b9zryLrFrS3yJVrmSQ0UlcwoPmwSEt"
 
+EXCEL_MIME_TYPES = [
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.ms-excel",
+]
+IMAGE_MIME_TYPES = [
+    "image/png",
+]
+
+
 def sync_drive_files():
-    files = list_excel_files_in_folder(FOLDER_ID)
+    os.makedirs("data", exist_ok=True)
+    os.makedirs("data/images", exist_ok=True)
+    files = list_files_in_folder(FOLDER_ID, EXCEL_MIME_TYPES + IMAGE_MIME_TYPES)
     local_files = []
     for f in files:
-        local_path = f"data/{f['name']}"
-        download_file(f['id'], local_path)
+        mime = f.get("mimeType", "")
+        if mime in EXCEL_MIME_TYPES:
+            local_path = os.path.join("data", f["name"])
+        elif mime in IMAGE_MIME_TYPES:
+            local_path = os.path.join("data/images", f["name"])
+        else:
+            continue
+        download_file(f["id"], local_path)
         local_files.append(local_path)
     return local_files

--- a/helpers/drive_watcher.py
+++ b/helpers/drive_watcher.py
@@ -1,0 +1,35 @@
+"""Simple Google Drive watcher that syncs files when changes are detected."""
+
+import time
+from helpers.drive_sync import sync_drive_files
+from helpers.drive_browser import get_drive_service
+
+FOLDER_ID = "1-1b9zryLrFrS3yJVrmSQ0UlcwoPmwSEt"
+
+
+def watch_drive_folder(interval: int = 60) -> None:
+    """Watch the Google Drive folder for changes and sync new files."""
+    service = get_drive_service()
+    page_token = service.changes().getStartPageToken().execute()["startPageToken"]
+    while True:
+        response = service.changes().list(
+            pageToken=page_token,
+            spaces="drive",
+            fields="nextPageToken, newStartPageToken, changes(fileId, removed, file(id, name, mimeType, parents))",
+        ).execute()
+        for change in response.get("changes", []):
+            file = change.get("file")
+            if file and not change.get("removed") and FOLDER_ID in file.get("parents", []):
+                print(f"Detected change in: {file['name']}")
+                sync_drive_files()
+        if "newStartPageToken" in response:
+            page_token = response["newStartPageToken"]
+        elif response.get("nextPageToken"):
+            page_token = response["nextPageToken"]
+        time.sleep(interval)
+
+
+if __name__ == "__main__":
+    sync_drive_files()
+    watch_drive_folder()
+


### PR DESCRIPTION
## Summary
- Watch Google Drive folder for changes and sync Excel/PNG files locally
- Support generic file listing and reliable downloads in Drive client
- Document continuous Drive watcher usage in README

## Testing
- `python -m py_compile helpers/drive_browser.py helpers/drive_sync.py helpers/drive_watcher.py`


------
https://chatgpt.com/codex/tasks/task_e_68be9197dcac8332830b2c2504dfbb22